### PR TITLE
Fixing gcc linkage issue (C11 Standards 6.7.4)

### DIFF
--- a/external/KentLib/lib/cirTree.c
+++ b/external/KentLib/lib/cirTree.c
@@ -451,7 +451,7 @@ if (crt != NULL)
     }
 }
 
-inline int cmpTwoBits32(bits32 aHi, bits32 aLo, bits32 bHi, bits32 bLo)
+static inline int cmpTwoBits32(bits32 aHi, bits32 aLo, bits32 bHi, bits32 bLo)
 /* Return - if b is less than a , 0 if equal, else +*/
 {
 if (aHi < bHi)


### PR DESCRIPTION
After compiling with GNU gcc or installing via pip I can't import wWigIO:

>>> import wWigIO
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: /root/venv/lib/python2.7/site-packages/wWigIO.so: undefined symbol: cmpTwoBits32

Either giving it internal linkage with "static inline" or external linkage in the header would fix the issue.